### PR TITLE
Add MPMtracker class implementing McLeod Pitch Method

### DIFF
--- a/Source/MPMtracker.cpp
+++ b/Source/MPMtracker.cpp
@@ -1,0 +1,80 @@
+#include "MPMtracker.h"
+#include <algorithm>
+
+MPMtracker::MPMtracker(float sr) : sampleRate(sr) {}
+
+void MPMtracker::setSampleRate(float newSampleRate)
+{
+    sampleRate = newSampleRate;
+}
+
+float MPMtracker::getSampleRate() const
+{
+    return sampleRate;
+}
+
+float MPMtracker::getPitch(const float* samples, int numSamples)
+{
+    if (samples == nullptr || numSamples < 2)
+        return 0.0f;
+
+    const int maxTau = numSamples / 2;
+    if (maxTau <= 1)
+        return 0.0f;
+
+    std::vector<float> nsdf(static_cast<size_t>(maxTau), 0.0f);
+
+    for (int tau = 0; tau < maxTau; ++tau)
+    {
+        float acf = 0.0f;
+        float norm = 0.0f;
+
+        for (int i = 0; i < numSamples - tau; ++i)
+        {
+            const float x1 = samples[i];
+            const float x2 = samples[i + tau];
+            acf += x1 * x2;
+            norm += x1 * x1 + x2 * x2;
+        }
+
+        nsdf[static_cast<size_t>(tau)] = (norm > 0.0f) ? (2.0f * acf / norm) : 0.0f;
+    }
+
+    int tauMax = 0;
+    float maxVal = -1.0f;
+    bool pastZero = false;
+
+    for (int tau = 1; tau < maxTau - 1; ++tau)
+    {
+        const float val = nsdf[static_cast<size_t>(tau)];
+
+        if (!pastZero && val < 0.0f)
+            pastZero = true;
+
+        if (pastZero && val > nsdf[static_cast<size_t>(tau - 1)] &&
+            val >= nsdf[static_cast<size_t>(tau + 1)] && val > maxVal)
+        {
+            maxVal = val;
+            tauMax = tau;
+        }
+    }
+
+    if (tauMax == 0 || maxVal <= 0.0f)
+        return 0.0f;
+
+    float betterTau = static_cast<float>(tauMax);
+
+    if (tauMax > 0 && tauMax < maxTau - 1)
+    {
+        const float s0 = nsdf[static_cast<size_t>(tauMax - 1)];
+        const float s1 = nsdf[static_cast<size_t>(tauMax)];
+        const float s2 = nsdf[static_cast<size_t>(tauMax + 1)];
+        const float denom = 2.0f * (2.0f * s1 - s2 - s0);
+
+        if (denom != 0.0f)
+            betterTau += (s2 - s0) / denom;
+    }
+
+    return sampleRate / betterTau;
+}
+

--- a/Source/MPMtracker.h
+++ b/Source/MPMtracker.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <vector>
+
+/**
+    Calculates the fundamental frequency of a signal using the
+    McLeod Pitch Method (MPM).
+*/
+class MPMtracker
+{
+public:
+    /** Creates an MPMtracker with the given sample rate. */
+    explicit MPMtracker(float sampleRate = 44100.0f);
+
+    /** Sets the sample rate to use for pitch estimation. */
+    void setSampleRate(float newSampleRate);
+
+    /** Returns the current sample rate. */
+    float getSampleRate() const;
+
+    /**
+        Estimates the fundamental frequency of the provided buffer.
+        
+        @param samples     Pointer to the audio samples.
+        @param numSamples  Number of samples in the buffer.
+        @returns Estimated pitch in Hz or 0.0f if no pitch was found.
+    */
+    float getPitch(const float* samples, int numSamples);
+
+private:
+    float sampleRate;
+};
+

--- a/testProjectWithCodex.jucer
+++ b/testProjectWithCodex.jucer
@@ -11,6 +11,8 @@
       <FILE id="XIGygt" name="PluginEditor.cpp" compile="1" resource="0"
             file="Source/PluginEditor.cpp"/>
       <FILE id="kIyYJP" name="PluginEditor.h" compile="0" resource="0" file="Source/PluginEditor.h"/>
+      <FILE id="ENpMTP" name="MPMtracker.cpp" compile="1" resource="0" file="Source/MPMtracker.cpp"/>
+      <FILE id="QYPHiQ" name="MPMtracker.h" compile="0" resource="0" file="Source/MPMtracker.h"/>
     </GROUP>
   </MAINGROUP>
   <MODULES>


### PR DESCRIPTION
## Summary
- add `MPMtracker` class for estimating fundamental frequency via McLeod Pitch Method
- include the new source files in the JUCE project definition

## Testing
- `g++ -std=c++17 -c Source/MPMtracker.cpp -o /tmp/MPMtracker.o`


------
https://chatgpt.com/codex/tasks/task_e_68a59bbce8b8833096c575bb3144470b