### PR TITLE
Add MPMtracker and GUI controls

### DIFF
--- a/Source/MPMtracker.cpp
+++ b/Source/MPMtracker.cpp
@@ -1,0 +1,80 @@
+#include "MPMtracker.h"
+#include <algorithm>
+
+MPMtracker::MPMtracker(float sr) : sampleRate(sr) {}
+
+void MPMtracker::setSampleRate(float newSampleRate)
+{
+    sampleRate = newSampleRate;
+}
+
+float MPMtracker::getSampleRate() const
+{
+    return sampleRate;
+}
+
+float MPMtracker::getPitch(const float* samples, int numSamples)
+{
+    if (samples == nullptr || numSamples < 2)
+        return 0.0f;
+
+    const int maxTau = numSamples / 2;
+    if (maxTau <= 1)
+        return 0.0f;
+
+    std::vector<float> nsdf(static_cast<size_t>(maxTau), 0.0f);
+
+    for (int tau = 0; tau < maxTau; ++tau)
+    {
+        float acf = 0.0f;
+        float norm = 0.0f;
+
+        for (int i = 0; i < numSamples - tau; ++i)
+        {
+            const float x1 = samples[i];
+            const float x2 = samples[i + tau];
+            acf += x1 * x2;
+            norm += x1 * x1 + x2 * x2;
+        }
+
+        nsdf[static_cast<size_t>(tau)] = (norm > 0.0f) ? (2.0f * acf / norm) : 0.0f;
+    }
+
+    int tauMax = 0;
+    float maxVal = -1.0f;
+    bool pastZero = false;
+
+    for (int tau = 1; tau < maxTau - 1; ++tau)
+    {
+        const float val = nsdf[static_cast<size_t>(tau)];
+
+        if (!pastZero && val < 0.0f)
+            pastZero = true;
+
+        if (pastZero && val > nsdf[static_cast<size_t>(tau - 1)] &&
+            val >= nsdf[static_cast<size_t>(tau + 1)] && val > maxVal)
+        {
+            maxVal = val;
+            tauMax = tau;
+        }
+    }
+
+    if (tauMax == 0 || maxVal <= 0.0f)
+        return 0.0f;
+
+    float betterTau = static_cast<float>(tauMax);
+
+    if (tauMax > 0 && tauMax < maxTau - 1)
+    {
+        const float s0 = nsdf[static_cast<size_t>(tauMax - 1)];
+        const float s1 = nsdf[static_cast<size_t>(tauMax)];
+        const float s2 = nsdf[static_cast<size_t>(tauMax + 1)];
+        const float denom = 2.0f * (2.0f * s1 - s2 - s0);
+
+        if (denom != 0.0f)
+            betterTau += (s2 - s0) / denom;
+    }
+
+    return sampleRate / betterTau;
+}
+

--- a/Source/MPMtracker.h
+++ b/Source/MPMtracker.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <vector>
+
+/**
+    Calculates the fundamental frequency of a signal using the
+    McLeod Pitch Method (MPM).
+*/
+class MPMtracker
+{
+public:
+    /** Creates an MPMtracker with the given sample rate. */
+    explicit MPMtracker(float sampleRate = 44100.0f);
+
+    /** Sets the sample rate to use for pitch estimation. */
+    void setSampleRate(float newSampleRate);
+
+    /** Returns the current sample rate. */
+    float getSampleRate() const;
+
+    /**
+        Estimates the fundamental frequency of the provided buffer.
+        
+        @param samples     Pointer to the audio samples.
+        @param numSamples  Number of samples in the buffer.
+        @returns Estimated pitch in Hz or 0.0f if no pitch was found.
+    */
+    float getPitch(const float* samples, int numSamples);
+
+private:
+    float sampleRate;
+};
+

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -16,6 +16,25 @@ TestProjectWithCodexAudioProcessorEditor::TestProjectWithCodexAudioProcessorEdit
     // Make sure that before the constructor has finished, you've set the
     // editor's size to whatever you need it to be.
     setSize (400, 300);
+
+    // Q slider
+    qSlider.setSliderStyle (juce::Slider::RotaryHorizontalVerticalDrag);
+    qSlider.setRange (0.0f, 1.0f, 0.001f);
+    qSlider.setValue (0.0f);
+    qSlider.setTextBoxStyle (juce::Slider::TextBoxBelow, false, 60, 20);
+    addAndMakeVisible (qSlider);
+
+    // Drive slider
+    driveSlider.setSliderStyle (juce::Slider::RotaryHorizontalVerticalDrag);
+    driveSlider.setRange (1.0f, 20.0f, 0.01f);
+    driveSlider.setValue (1.0f);
+    driveSlider.setTextBoxStyle (juce::Slider::TextBoxBelow, false, 60, 20);
+    addAndMakeVisible (driveSlider);
+
+    // Mode tabs
+    modeTabs.addTab ("BPF12", juce::Colours::lightgrey, new juce::Component(), true);
+    modeTabs.addTab ("BPF24", juce::Colours::lightgrey, new juce::Component(), true);
+    addAndMakeVisible (modeTabs);
 }
 
 TestProjectWithCodexAudioProcessorEditor::~TestProjectWithCodexAudioProcessorEditor()
@@ -27,14 +46,16 @@ void TestProjectWithCodexAudioProcessorEditor::paint (juce::Graphics& g)
 {
     // (Our component is opaque, so we must completely fill the background with a solid colour)
     g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
-
-    g.setColour (juce::Colours::white);
-    g.setFont (juce::FontOptions (15.0f));
-    g.drawFittedText ("Hello World!", getLocalBounds(), juce::Justification::centred, 1);
 }
 
 void TestProjectWithCodexAudioProcessorEditor::resized()
 {
-    // This is generally where you'll want to lay out the positions of any
-    // subcomponents in your editor..
+    auto area = getLocalBounds();
+    auto tabHeight = 30;
+    modeTabs.setBounds (area.removeFromTop (tabHeight));
+
+    auto sliderArea = area.reduced (10);
+    auto sliderWidth = sliderArea.getWidth() / 2;
+    qSlider.setBounds (sliderArea.removeFromLeft (sliderWidth).reduced (10));
+    driveSlider.setBounds (sliderArea.reduced (10));
 }

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -20,14 +20,16 @@ TestProjectWithCodexAudioProcessorEditor::TestProjectWithCodexAudioProcessorEdit
     // Q slider
     qSlider.setSliderStyle (juce::Slider::RotaryHorizontalVerticalDrag);
     qSlider.setRange (0.0f, 1.0f, 0.001f);
+    qSlider.onValueChange = [this] { audioProcessor.setQ ((float) qSlider.getValue()); };
     qSlider.setValue (0.0f);
     qSlider.setTextBoxStyle (juce::Slider::TextBoxBelow, false, 60, 20);
     addAndMakeVisible (qSlider);
 
     // Drive slider
     driveSlider.setSliderStyle (juce::Slider::RotaryHorizontalVerticalDrag);
-    driveSlider.setRange (1.0f, 20.0f, 0.01f);
-    driveSlider.setValue (1.0f);
+    driveSlider.setRange (0.0f, 20.0f, 0.01f);
+    driveSlider.onValueChange = [this] { audioProcessor.setDrive ((float) driveSlider.getValue()); };
+    driveSlider.setValue (0.0f);
     driveSlider.setTextBoxStyle (juce::Slider::TextBoxBelow, false, 60, 20);
     addAndMakeVisible (driveSlider);
 

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -29,5 +29,10 @@ private:
     // access the processor object that created it.
     TestProjectWithCodexAudioProcessor& audioProcessor;
 
+    // UI components
+    juce::Slider qSlider;
+    juce::Slider driveSlider;
+    juce::TabbedComponent modeTabs { juce::TabbedButtonBar::TabsAtTop };
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (TestProjectWithCodexAudioProcessorEditor)
 };

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <JuceHeader.h>
+#include "MPMtracker.h"
 
 //==============================================================================
 /**
@@ -29,6 +30,10 @@ public:
    #endif
 
     void processBlock (juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
+
+    // Parameter setters used by the editor
+    void setQ (float newQ);
+    void setDrive (float newDrive);
 
     //==============================================================================
     juce::AudioProcessorEditor* createEditor() override;
@@ -55,5 +60,10 @@ public:
 
 private:
     //==============================================================================
+    juce::dsp::LadderFilter<float> ladder;
+    MPMtracker pitchTracker;
+    std::atomic<float> q { 0.0f };
+    std::atomic<float> drive { 0.0f };
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (TestProjectWithCodexAudioProcessor)
 };

--- a/testProjectWithCodex.jucer
+++ b/testProjectWithCodex.jucer
@@ -11,6 +11,8 @@
       <FILE id="XIGygt" name="PluginEditor.cpp" compile="1" resource="0"
             file="Source/PluginEditor.cpp"/>
       <FILE id="kIyYJP" name="PluginEditor.h" compile="0" resource="0" file="Source/PluginEditor.h"/>
+      <FILE id="ENpMTP" name="MPMtracker.cpp" compile="1" resource="0" file="Source/MPMtracker.cpp"/>
+      <FILE id="QYPHiQ" name="MPMtracker.h" compile="0" resource="0" file="Source/MPMtracker.h"/>
     </GROUP>
   </MAINGROUP>
   <MODULES>


### PR DESCRIPTION
## Summary
- add `MPMtracker` class for estimating fundamental frequency via McLeod Pitch Method
- add `Q` and `Drive` rotary controls and a `Mode` tab selector to the plugin editor
- include the new source files in the JUCE project definition

## Testing
- `g++ -std=c++17 -c Source/MPMtracker.cpp -o /tmp/MPMtracker.o`
- `g++ -std=c++17 -I JuceLibraryCode -c Source/PluginEditor.cpp -o /tmp/PluginEditor.o` *(fails: juce_audio_basics/juce_audio_basics.h: No such file or directory)*
- `sudo apt-get update` *(fails: repository InRelease is not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a59bbce8b8833096c575bb3144470b