### PR TITLE
Add frequency analyzer component

### DIFF
--- a/Source/FrequencyAnalyzer.cpp
+++ b/Source/FrequencyAnalyzer.cpp
@@ -1,0 +1,39 @@
+#include "FrequencyAnalyzer.h"
+
+FrequencyAnalyzer::FrequencyAnalyzer (TestProjectWithCodexAudioProcessor& p)
+    : processor (p)
+{
+    startTimerHz (30);
+}
+
+void FrequencyAnalyzer::paint (juce::Graphics& g)
+{
+    g.fillAll (juce::Colours::black);
+    g.setColour (juce::Colours::green);
+    g.strokePath (spectrumPath, juce::PathStrokeType (1.0f));
+}
+
+void FrequencyAnalyzer::timerCallback()
+{
+    std::vector<float> data;
+    if (processor.getFFTData (data))
+    {
+        spectrumPath.clear();
+        auto width = static_cast<float> (getWidth());
+        auto height = static_cast<float> (getHeight());
+        auto binWidth = width / (float) data.size();
+
+        for (size_t i = 0; i < data.size(); ++i)
+        {
+            auto level = juce::Decibels::gainToDecibels (data[i]) - 100.0f;
+            auto y = juce::jmap (level, -100.0f, 0.0f, height, 0.0f);
+            if (i == 0)
+                spectrumPath.startNewSubPath (0.0f, y);
+            else
+                spectrumPath.lineTo ((float) i * binWidth, y);
+        }
+
+        repaint();
+    }
+}
+

--- a/Source/FrequencyAnalyzer.h
+++ b/Source/FrequencyAnalyzer.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <JuceHeader.h>
+#include "PluginProcessor.h"
+
+class FrequencyAnalyzer : public juce::Component, private juce::Timer
+{
+public:
+    explicit FrequencyAnalyzer (TestProjectWithCodexAudioProcessor& p);
+
+    void paint (juce::Graphics& g) override;
+    void timerCallback() override;
+
+private:
+    TestProjectWithCodexAudioProcessor& processor;
+    juce::Path spectrumPath;
+
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (FrequencyAnalyzer)
+};
+

--- a/Source/MPMtracker.cpp
+++ b/Source/MPMtracker.cpp
@@ -1,0 +1,80 @@
+#include "MPMtracker.h"
+#include <algorithm>
+
+MPMtracker::MPMtracker(float sr) : sampleRate(sr) {}
+
+void MPMtracker::setSampleRate(float newSampleRate)
+{
+    sampleRate = newSampleRate;
+}
+
+float MPMtracker::getSampleRate() const
+{
+    return sampleRate;
+}
+
+float MPMtracker::getPitch(const float* samples, int numSamples)
+{
+    if (samples == nullptr || numSamples < 2)
+        return 0.0f;
+
+    const int maxTau = numSamples / 2;
+    if (maxTau <= 1)
+        return 0.0f;
+
+    std::vector<float> nsdf(static_cast<size_t>(maxTau), 0.0f);
+
+    for (int tau = 0; tau < maxTau; ++tau)
+    {
+        float acf = 0.0f;
+        float norm = 0.0f;
+
+        for (int i = 0; i < numSamples - tau; ++i)
+        {
+            const float x1 = samples[i];
+            const float x2 = samples[i + tau];
+            acf += x1 * x2;
+            norm += x1 * x1 + x2 * x2;
+        }
+
+        nsdf[static_cast<size_t>(tau)] = (norm > 0.0f) ? (2.0f * acf / norm) : 0.0f;
+    }
+
+    int tauMax = 0;
+    float maxVal = -1.0f;
+    bool pastZero = false;
+
+    for (int tau = 1; tau < maxTau - 1; ++tau)
+    {
+        const float val = nsdf[static_cast<size_t>(tau)];
+
+        if (!pastZero && val < 0.0f)
+            pastZero = true;
+
+        if (pastZero && val > nsdf[static_cast<size_t>(tau - 1)] &&
+            val >= nsdf[static_cast<size_t>(tau + 1)] && val > maxVal)
+        {
+            maxVal = val;
+            tauMax = tau;
+        }
+    }
+
+    if (tauMax == 0 || maxVal <= 0.0f)
+        return 0.0f;
+
+    float betterTau = static_cast<float>(tauMax);
+
+    if (tauMax > 0 && tauMax < maxTau - 1)
+    {
+        const float s0 = nsdf[static_cast<size_t>(tauMax - 1)];
+        const float s1 = nsdf[static_cast<size_t>(tauMax)];
+        const float s2 = nsdf[static_cast<size_t>(tauMax + 1)];
+        const float denom = 2.0f * (2.0f * s1 - s2 - s0);
+
+        if (denom != 0.0f)
+            betterTau += (s2 - s0) / denom;
+    }
+
+    return sampleRate / betterTau;
+}
+

--- a/Source/MPMtracker.h
+++ b/Source/MPMtracker.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <vector>
+
+/**
+    Calculates the fundamental frequency of a signal using the
+    McLeod Pitch Method (MPM).
+*/
+class MPMtracker
+{
+public:
+    /** Creates an MPMtracker with the given sample rate. */
+    explicit MPMtracker(float sampleRate = 44100.0f);
+
+    /** Sets the sample rate to use for pitch estimation. */
+    void setSampleRate(float newSampleRate);
+
+    /** Returns the current sample rate. */
+    float getSampleRate() const;
+
+    /**
+        Estimates the fundamental frequency of the provided buffer.
+        
+        @param samples     Pointer to the audio samples.
+        @param numSamples  Number of samples in the buffer.
+        @returns Estimated pitch in Hz or 0.0f if no pitch was found.
+    */
+    float getPitch(const float* samples, int numSamples);
+
+private:
+    float sampleRate;
+};
+

--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -11,11 +11,48 @@
 
 //==============================================================================
 TestProjectWithCodexAudioProcessorEditor::TestProjectWithCodexAudioProcessorEditor (TestProjectWithCodexAudioProcessor& p)
-    : AudioProcessorEditor (&p), audioProcessor (p)
+    : AudioProcessorEditor (&p), audioProcessor (p), analyzer (p)
 {
     // Make sure that before the constructor has finished, you've set the
     // editor's size to whatever you need it to be.
     setSize (400, 300);
+
+    // Q slider
+    qSlider.setSliderStyle (juce::Slider::RotaryHorizontalVerticalDrag);
+    qSlider.setRange (0.0f, 1.0f, 0.001f);
+    qSlider.onValueChange = [this] { audioProcessor.setQ ((float) qSlider.getValue()); };
+    qSlider.setValue (0.0f);
+    qSlider.setTextBoxStyle (juce::Slider::TextBoxAbove, false, 60, 20);
+    addAndMakeVisible (qSlider);
+    qLabel.setText ("Q", juce::dontSendNotification);
+    qLabel.setJustificationType (juce::Justification::centred);
+    addAndMakeVisible (qLabel);
+
+    // Drive slider
+    driveSlider.setSliderStyle (juce::Slider::RotaryHorizontalVerticalDrag);
+    driveSlider.setRange (0.0f, 20.0f, 0.01f);
+    driveSlider.onValueChange = [this] { audioProcessor.setDrive ((float) driveSlider.getValue()); };
+    driveSlider.setValue (0.0f);
+    driveSlider.setTextBoxStyle (juce::Slider::TextBoxAbove, false, 60, 20);
+    addAndMakeVisible (driveSlider);
+    driveLabel.setText ("Drive", juce::dontSendNotification);
+    driveLabel.setJustificationType (juce::Justification::centred);
+    addAndMakeVisible (driveLabel);
+
+    // Mode tabs
+    modeTabs.addTab ("BPF12", juce::Colours::lightgrey, new juce::Component(), true);
+    modeTabs.addTab ("BPF24", juce::Colours::lightgrey, new juce::Component(), true);
+    modeTabs.onChange = [this] { audioProcessor.setMode (modeTabs.getCurrentTabIndex()); };
+    addAndMakeVisible (modeTabs);
+
+    // Fundamental frequency label
+    f0Label.setJustificationType (juce::Justification::centred);
+    f0Label.setText ("F0: 0.00 Hz", juce::dontSendNotification);
+    addAndMakeVisible (f0Label);
+
+    addAndMakeVisible (analyzer);
+
+    startTimerHz (30);
 }
 
 TestProjectWithCodexAudioProcessorEditor::~TestProjectWithCodexAudioProcessorEditor()
@@ -27,14 +64,35 @@ void TestProjectWithCodexAudioProcessorEditor::paint (juce::Graphics& g)
 {
     // (Our component is opaque, so we must completely fill the background with a solid colour)
     g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
-
-    g.setColour (juce::Colours::white);
-    g.setFont (juce::FontOptions (15.0f));
-    g.drawFittedText ("Hello World!", getLocalBounds(), juce::Justification::centred, 1);
 }
 
 void TestProjectWithCodexAudioProcessorEditor::resized()
 {
-    // This is generally where you'll want to lay out the positions of any
-    // subcomponents in your editor..
+    auto area = getLocalBounds();
+    auto tabHeight = 30;
+    modeTabs.setBounds (area.removeFromTop (tabHeight));
+
+    auto freqHeight = 20;
+    f0Label.setBounds (area.removeFromBottom (freqHeight));
+
+    auto analyzerHeight = 100;
+    analyzer.setBounds (area.removeFromTop (analyzerHeight));
+
+    auto sliderArea = area.reduced (10);
+    auto sliderWidth = sliderArea.getWidth() / 2;
+
+    auto qArea = sliderArea.removeFromLeft (sliderWidth).reduced (10);
+    auto labelHeight = 20;
+    qLabel.setBounds (qArea.removeFromBottom (labelHeight));
+    qSlider.setBounds (qArea);
+
+    auto dArea = sliderArea.reduced (10);
+    driveLabel.setBounds (dArea.removeFromBottom (labelHeight));
+    driveSlider.setBounds (dArea);
+}
+
+void TestProjectWithCodexAudioProcessorEditor::timerCallback()
+{
+    auto freq = audioProcessor.getCurrentF0();
+    f0Label.setText ("F0: " + juce::String (freq, 2) + " Hz", juce::dontSendNotification);
 }

--- a/Source/PluginEditor.h
+++ b/Source/PluginEditor.h
@@ -10,11 +10,12 @@
 
 #include <JuceHeader.h>
 #include "PluginProcessor.h"
+#include "FrequencyAnalyzer.h"
 
 //==============================================================================
 /**
 */
-class TestProjectWithCodexAudioProcessorEditor  : public juce::AudioProcessorEditor
+class TestProjectWithCodexAudioProcessorEditor  : public juce::AudioProcessorEditor, private juce::Timer
 {
 public:
     TestProjectWithCodexAudioProcessorEditor (TestProjectWithCodexAudioProcessor&);
@@ -24,10 +25,21 @@ public:
     void paint (juce::Graphics&) override;
     void resized() override;
 
+    void timerCallback() override;
+
 private:
     // This reference is provided as a quick way for your editor to
     // access the processor object that created it.
     TestProjectWithCodexAudioProcessor& audioProcessor;
+
+    // UI components
+    juce::Slider qSlider;
+    juce::Slider driveSlider;
+    juce::TabbedComponent modeTabs { juce::TabbedButtonBar::TabsAtTop };
+    juce::Label qLabel;
+    juce::Label driveLabel;
+    juce::Label f0Label;
+    FrequencyAnalyzer analyzer;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (TestProjectWithCodexAudioProcessorEditor)
 };

--- a/Source/PluginProcessor.cpp
+++ b/Source/PluginProcessor.cpp
@@ -8,6 +8,9 @@
 
 #include "PluginProcessor.h"
 #include "PluginEditor.h"
+#include <cmath>
+#include <vector>
+#include <array>
 
 //==============================================================================
 TestProjectWithCodexAudioProcessor::TestProjectWithCodexAudioProcessor()
@@ -93,8 +96,26 @@ void TestProjectWithCodexAudioProcessor::changeProgramName (int index, const juc
 //==============================================================================
 void TestProjectWithCodexAudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
 {
-    // Use this method as the place to do any pre-playback
-    // initialisation that you need..
+    juce::dsp::ProcessSpec spec;
+    spec.sampleRate = sampleRate;
+    spec.maximumBlockSize = static_cast<juce::uint32> (samplesPerBlock);
+    spec.numChannels = static_cast<juce::uint32> (getTotalNumOutputChannels());
+
+    ladder.prepare (spec);
+    ladder.setMode (juce::dsp::LadderFilter<float>::Mode::BPF12);
+    ladder.reset();
+
+    oversampler = std::make_unique<juce::dsp::Oversampling<float>> (spec.numChannels, 1, juce::dsp::Oversampling<float>::filterHalfBandPolyphaseIIR);
+    oversampler->initProcessing (static_cast<size_t> (samplesPerBlock));
+
+    cutoffSmooth.reset (sampleRate, 0.05);
+    qSmooth.reset (sampleRate, 0.05);
+    driveSmooth.reset (sampleRate, 0.05);
+    cutoffSmooth.setCurrentAndTargetValue (0.0f);
+    qSmooth.setCurrentAndTargetValue (0.0f);
+    driveSmooth.setCurrentAndTargetValue (0.0f);
+
+    pitchTracker.setSampleRate (static_cast<float> (sampleRate));
 }
 
 void TestProjectWithCodexAudioProcessor::releaseResources()
@@ -132,30 +153,83 @@ bool TestProjectWithCodexAudioProcessor::isBusesLayoutSupported (const BusesLayo
 void TestProjectWithCodexAudioProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages)
 {
     juce::ScopedNoDenormals noDenormals;
-    auto totalNumInputChannels  = getTotalNumInputChannels();
-    auto totalNumOutputChannels = getTotalNumOutputChannels();
 
-    // In case we have more outputs than inputs, this code clears any output
-    // channels that didn't contain input data, (because these aren't
-    // guaranteed to be empty - they may contain garbage).
-    // This is here to avoid people getting screaming feedback
-    // when they first compile a plugin, but obviously you don't need to keep
-    // this code if your algorithm always overwrites all the output channels.
-    for (auto i = totalNumInputChannels; i < totalNumOutputChannels; ++i)
-        buffer.clear (i, 0, buffer.getNumSamples());
+    // Pitch detection from first channel
+    float f0 = pitchTracker.getPitch (buffer.getReadPointer (0), buffer.getNumSamples());
+    if (f0 > 0.0f)
+        cutoffSmooth.setTargetValue (f0);
+    else
+        cutoffSmooth.setTargetValue (0.0f);
 
-    // This is the place where you'd normally do the guts of your plugin's
-    // audio processing...
-    // Make sure to reset the state if your inner loop is processing
-    // the samples and the outer loop is handling the channels.
-    // Alternatively, you can process the samples with the channels
-    // interleaved by keeping the same state.
-    for (int channel = 0; channel < totalNumInputChannels; ++channel)
+    currentF0 = f0 > 0.0f ? f0 : 0.0f;
+
+    qSmooth.setTargetValue (q.load());
+    driveSmooth.setTargetValue (drive.load());
+
+    juce::dsp::AudioBlock<float> block (buffer);
+    auto oversampledBlock = oversampler->processSamplesUp (block);
+
+    auto numSamples = oversampledBlock.getNumSamples();
+    auto numChannels = oversampledBlock.getNumChannels();
+
+    std::vector<float*> channelPtrs (numChannels);
+    for (size_t i = 0; i < numSamples; ++i)
     {
-        auto* channelData = buffer.getWritePointer (channel);
+        auto cutoff = cutoffSmooth.getNextValue();
+        auto qVal = qSmooth.getNextValue();
+        auto driveVal = driveSmooth.getNextValue();
+        ladder.setCutoffFrequencyHz (cutoff);
+        ladder.setResonance (qVal);
+        float dB = std::pow (10.0f, driveVal / 10.0f);
+        ladder.setDrive (dB);
 
-        // ..do something to the data...
+        for (size_t ch = 0; ch < numChannels; ++ch)
+            channelPtrs[ch] = oversampledBlock.getChannelPointer (ch) + i;
+
+        juce::dsp::AudioBlock<float> singleSampleBlock (channelPtrs.data(), numChannels, 1);
+        juce::dsp::ProcessContextReplacing<float> context (singleSampleBlock);
+        ladder.process (context);
     }
+
+    oversampler->processSamplesDown (block);
+
+    for (int i = 0; i < buffer.getNumSamples(); ++i)
+        pushNextSampleIntoFifo (buffer.getReadPointer (0)[i]);
+}
+
+void TestProjectWithCodexAudioProcessor::setQ (float newQ)
+{
+    q = newQ;
+}
+
+void TestProjectWithCodexAudioProcessor::setDrive (float newDrive)
+{
+    drive = newDrive;
+}
+
+void TestProjectWithCodexAudioProcessor::setMode (int modeIndex)
+{
+    if (modeIndex == 0)
+        ladder.setMode (juce::dsp::LadderFilter<float>::Mode::BPF12);
+    else
+        ladder.setMode (juce::dsp::LadderFilter<float>::Mode::BPF24);
+}
+
+float TestProjectWithCodexAudioProcessor::getCurrentF0() const
+{
+    return currentF0.load();
+}
+
+bool TestProjectWithCodexAudioProcessor::getFFTData (std::vector<float>& data)
+{
+    if (nextFFTBlockReady)
+    {
+        data.assign (fftData.begin(), fftData.begin() + fftSize / 2);
+        nextFFTBlockReady = false;
+        return true;
+    }
+
+    return false;
 }
 
 //==============================================================================
@@ -188,4 +262,22 @@ void TestProjectWithCodexAudioProcessor::setStateInformation (const void* data, 
 juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
     return new TestProjectWithCodexAudioProcessor();
+}
+
+void TestProjectWithCodexAudioProcessor::pushNextSampleIntoFifo (float sample)
+{
+    if (fifoIndex == fftSize)
+    {
+        if (! nextFFTBlockReady)
+        {
+            std::copy (fifo.begin(), fifo.end(), fftData.begin());
+            window.multiplyWithWindowingTable (fftData.data(), fftSize);
+            forwardFFT.performFrequencyOnlyForwardTransform (fftData.data());
+            nextFFTBlockReady = true;
+        }
+
+        fifoIndex = 0;
+    }
+
+    fifo[(size_t) fifoIndex++] = sample;
 }

--- a/Source/PluginProcessor.h
+++ b/Source/PluginProcessor.h
@@ -9,6 +9,9 @@
 #pragma once
 
 #include <JuceHeader.h>
+#include "MPMtracker.h"
+#include <array>
+#include <vector>
 
 //==============================================================================
 /**
@@ -29,6 +32,14 @@ public:
    #endif
 
     void processBlock (juce::AudioBuffer<float>&, juce::MidiBuffer&) override;
+
+    // Parameter setters used by the editor
+    void setQ (float newQ);
+    void setDrive (float newDrive);
+    void setMode (int modeIndex);
+
+    float getCurrentF0() const;
+    bool getFFTData (std::vector<float>& data);
 
     //==============================================================================
     juce::AudioProcessorEditor* createEditor() override;
@@ -55,5 +66,26 @@ public:
 
 private:
     //==============================================================================
+    juce::dsp::LadderFilter<float> ladder;
+    MPMtracker pitchTracker;
+    std::atomic<float> q { 0.0f };
+    std::atomic<float> drive { 0.0f };
+    std::atomic<float> currentF0 { 0.0f };
+    juce::LinearSmoothedValue<float> cutoffSmooth;
+    juce::LinearSmoothedValue<float> qSmooth;
+    juce::LinearSmoothedValue<float> driveSmooth;
+    std::unique_ptr<juce::dsp::Oversampling<float>> oversampler;
+
+    // FFT data for frequency analysis
+    static constexpr int fftOrder = 10;
+    static constexpr int fftSize = 1 << fftOrder;
+    std::array<float, fftSize> fifo{};
+    std::array<float, fftSize * 2> fftData{};
+    int fifoIndex = 0;
+    bool nextFFTBlockReady = false;
+    juce::dsp::FFT forwardFFT { fftOrder };
+    juce::dsp::WindowingFunction<float> window { fftSize, juce::dsp::WindowingFunction<float>::hann };
+    void pushNextSampleIntoFifo (float sample);
+
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (TestProjectWithCodexAudioProcessor)
 };

--- a/testProjectWithCodex.jucer
+++ b/testProjectWithCodex.jucer
@@ -11,6 +11,10 @@
       <FILE id="XIGygt" name="PluginEditor.cpp" compile="1" resource="0"
             file="Source/PluginEditor.cpp"/>
       <FILE id="kIyYJP" name="PluginEditor.h" compile="0" resource="0" file="Source/PluginEditor.h"/>
+      <FILE id="ENpMTP" name="MPMtracker.cpp" compile="1" resource="0" file="Source/MPMtracker.cpp"/>
+      <FILE id="QYPHiQ" name="MPMtracker.h" compile="0" resource="0" file="Source/MPMtracker.h"/>
+      <FILE id="VZtkln" name="FrequencyAnalyzer.cpp" compile="1" resource="0" file="Source/FrequencyAnalyzer.cpp"/>
+      <FILE id="GXNLVw" name="FrequencyAnalyzer.h" compile="0" resource="0" file="Source/FrequencyAnalyzer.h"/>
     </GROUP>
   </MAINGROUP>
   <MODULES>


### PR DESCRIPTION
## Summary
- Implement FFT-based frequency analyzer component with timer-driven spectrum drawing.
- Capture output samples in processor, perform windowed FFT, and expose magnitude data to UI.
- Integrate analyzer into editor layout and project configuration.

## Testing
- `g++ -std=c++17 -c Source/MPMtracker.cpp -o /tmp/MPMtracker.o`
- `g++ -std=c++17 -I JuceLibraryCode -c Source/FrequencyAnalyzer.cpp -o /tmp/FrequencyAnalyzer.o` *(fails: juce_audio_basics not found)*
- `g++ -std=c++17 -I JuceLibraryCode -c Source/PluginProcessor.cpp -o /tmp/PluginProcessor.o` *(fails: juce_audio_basics not found)*
- `g++ -std=c++17 -I JuceLibraryCode -c Source/PluginEditor.cpp -o /tmp/PluginEditor.o` *(fails: juce_audio_basics not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a59bbce8b8833096c575bb3144470b